### PR TITLE
do ddox manually in dub.json

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -3,5 +3,17 @@
     "description": "a statistics package for D",
     "authors": ["David Simcha", "Don Clugston"],
     "homepage": "https://github.com/John-Colvin/dstats",
-    "license": "various"
+    "license": "various",
+
+    "buildTypes": {
+        "DSddox": {
+            "buildOptions": ["syntaxOnly"],
+            "dflags": ["-c", "-Df__dummy.html", "-Xfdocs.json"],
+            "postBuildCommands": [
+                "rm -rf site/api",
+                "ddox filter --min-protection=Protected docs.json",
+                "ddox generate-html --file-name-style=lowerCase --navigation-type=ModuleTree docs.json site/api"
+            ]
+        }
+    }
 }

--- a/gen_docs
+++ b/gen_docs
@@ -1,7 +1,0 @@
-#!/usr/bin/env bash
-
-set -e
-
-dub build --build=ddox
-rm -rf site/api
-mv docs site/api


### PR DESCRIPTION
also move to lower-case page names to avoid any case-sensitivity problems on Windows or OS X.

Don't merge yet
