### PR TITLE
Fix various errors and deprecation warnings with dmd 2.071.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.dub
+__*
+dub.selections.json

--- a/source/dstats/base.d
+++ b/source/dstats/base.d
@@ -1376,7 +1376,7 @@ unittest {
     bool[uint[]] results;  // Keep track of how many UNIQUE items we have.
     auto comb3 = Comb!(uint)(seq(10U, 22U), 6);
     foreach(c; comb3) {
-        auto dupped = c.dup.sort;
+        auto dupped = c.dup.sort();
         // Make sure all elems are unique and within range.
         assert(dupped.length == 6);
         assert(dupped[0] > 9 && dupped[0] < 22);
@@ -1385,7 +1385,7 @@ unittest {
             assert(dupped[i] > dupped[i - 1]);
             assert(dupped[i] > 9 && dupped[i] < 22);
         }
-        results[dupped.idup] = true;
+        results[dupped.array.idup] = true;
     }
     assert(results.length == 924);  // (12 choose 6).
 }

--- a/source/dstats/cor.d
+++ b/source/dstats/cor.d
@@ -392,14 +392,14 @@ unittest {
         double sFour =
              -spearmanCor(two[lowerBound..upperBound], one[lowerBound..upperBound]);
         foreach(ref o; two) o*=-1;
-        one[lowerBound..upperBound].reverse;
-        two[lowerBound..upperBound].reverse;
+        one[lowerBound..upperBound].reverse();
+        two[lowerBound..upperBound].reverse();
         double sFive =
              spearmanCor(one[lowerBound..upperBound], two[lowerBound..upperBound]);
-        assert(approxEqual(sOne, sTwo) || (isnan(sOne) && isnan(sTwo)));
-        assert(approxEqual(sTwo, sThree) || (isnan(sThree) && isnan(sTwo)));
-        assert(approxEqual(sThree, sFour) || (isnan(sThree) && isnan(sFour)));
-        assert(approxEqual(sFour, sFive) || (isnan(sFour) && isnan(sFive)));
+        assert(approxEqual(sOne, sTwo) || (isNaN(sOne) && isNaN(sTwo)));
+        assert(approxEqual(sTwo, sThree) || (isNaN(sThree) && isNaN(sTwo)));
+        assert(approxEqual(sThree, sFour) || (isNaN(sThree) && isNaN(sFour)));
+        assert(approxEqual(sFour, sFive) || (isNaN(sFour) && isNaN(sFive)));
     }
 
     // Test input ranges.

--- a/source/dstats/distrib.d
+++ b/source/dstats/distrib.d
@@ -1744,7 +1744,7 @@ unittest {
     assert(approxEqual(invLaplaceCDF(0.82), 1.0217));
 }
 
-double kolmDist()(double x) {
+deprecated double kolmDist()(double x) {
     pragma(msg, "kolmDist is scheduled for deprecation.  Please use " ~
         "kolmogorovDistrib instead.");
         
@@ -1781,8 +1781,8 @@ double kolmogorovDistrib(immutable double x) {
 }
 
 unittest {
-    assert(approxEqual(1 - kolmDist(.75), 0.627167));
-    assert(approxEqual(1 - kolmDist(.5), 0.9639452436));
-    assert(approxEqual(1 - kolmDist(.9), 0.39273070));
-    assert(approxEqual(1 - kolmDist(1.2), 0.112249666));
+    assert(approxEqual(1 - kolmogorovDistrib(.75), 0.627167));
+    assert(approxEqual(1 - kolmogorovDistrib(.5), 0.9639452436));
+    assert(approxEqual(1 - kolmogorovDistrib(.9), 0.39273070));
+    assert(approxEqual(1 - kolmogorovDistrib(1.2), 0.112249666));
 }

--- a/source/dstats/random.d
+++ b/source/dstats/random.d
@@ -571,7 +571,7 @@ Step40:
     v = v*(u-p3)*lamr;
 
 Step50:
-    k = cast(int) fabs(y - m);
+    k = cast(int) abs(y - m);
     if ((k > 20) && (k < ((nrq)/2.0 - 1))) goto Step52;
 
     s = r/q;

--- a/source/dstats/regress.d
+++ b/source/dstats/regress.d
@@ -2237,6 +2237,7 @@ double computeMaxDist(const double[] stuff, double x) pure nothrow @safe {
 }
 
 double absMax(double a, double b) {
+    import std.algorithm : max;
     return max(abs(a), abs(b));
 }
 

--- a/source/dstats/regress.d
+++ b/source/dstats/regress.d
@@ -651,6 +651,7 @@ RegressRes linearRegress(U, TC...)(U Y, TC input) {
     }
     auto p = new double[betas.length];
 
+    import std.algorithm : min;
     foreach(i, beta; betas) {
         try {
             p[i] = 2 * min(studentsTCDF(beta / stdErr[i], df),
@@ -871,6 +872,7 @@ private MeanSD[] calculateSummaries(X...)(X xIn, RegionAllocator alloc) {
     ret[] = MeanSD.init;
 
     static if(allHaveLength) {
+        import std.algorithm : min;
         size_t minLen = size_t.max;
         foreach(range; x) {
             minLen = min(minLen, range.length);
@@ -925,6 +927,7 @@ private struct PreprocessedData {
 
 private PreprocessedData preprocessStandardize(Y, X...)
 (Y yIn, X xIn, RegionAllocator alloc) {
+    import std.algorithm : min, map, reduce;
     static if(X.length == 1 && isRoR!(X[0])) {
         auto xRaw = alloc.array(xIn[0]);
     } else {
@@ -1053,6 +1056,7 @@ private void coordDescent(
         }
     }
 
+    import std.algorithm : reduce, max, map;
     if(reduce!max(0.0, map!abs(betas)) > 0) {
         makePredictions();
     }
@@ -1569,6 +1573,7 @@ LogisticRes logisticRegress(T, V...)(T yIn, V input) {
 }
 
 unittest {
+    import std.algorithm : filter;
     // Values from R.  Confidence intervals from confint.default().
     // R doesn't automatically calculate likelihood ratio P-value, and reports
     // deviations instead of log likelihoods.  Deviations are just
@@ -2115,6 +2120,7 @@ public:
         immutable maxDist = computeMaxDist(x[firstNeighbor..lastNeighbor + 1], point);
         auto w = alloc.uninitializedArray!(double[])(yNeighbors.length);
         foreach(j, neighbor; x[firstNeighbor..lastNeighbor + 1]) {
+            import std.algorithm : max;
             immutable diff = abs(point - neighbor);
             w[j] = max(0, (1 - (diff / maxDist) ^^ 3) ^^ 3);
             if(robustness > 0) {
@@ -2221,6 +2227,7 @@ double biweight(double x) pure nothrow @safe {
 }
 
 double computeMaxDist(const double[] stuff, double x) pure nothrow @safe {
+    import std.algorithm : max;
     double ret = 0;
     foreach(elem; stuff) {
         ret = max(ret, abs(elem - x));
@@ -2272,6 +2279,8 @@ LogisticRes logisticRegressImpl(T, V...)
     ret.logLikelihood = doMLENewton(ret.betas, ret.stdErr, ridge, y, x);
 
     if(!inference) return ret;
+
+    import std.algorithm : filter;
 
     static bool hasNaNs(R)(R range) {
         return !filter!isNaN(range).empty;
@@ -2383,6 +2392,7 @@ private void logisticRegressPenalizedImpl(Y, X...)
         }
     }
 
+    import std.algorithm : reduce;
     foreach(iter; 0..maxIter) {
         evalPs(betas[0], ps, betas[1..$], x);
         immutable lh = logLikelihood(ps, y);
@@ -2473,6 +2483,7 @@ double[] calculateMSEs(U...)(U xIn, RegionAllocator alloc) {
         alias xIn x;
     }
 
+    import std.algorithm : min;
     size_t minLen = size_t.max;
     foreach(r; x) {
         static if(!isInfinite!(typeof(r))) {

--- a/source/dstats/tests.d
+++ b/source/dstats/tests.d
@@ -33,13 +33,15 @@ module dstats.tests;
 import std.functional, std.range, std.conv, std.math, std.traits,
        std.exception, std.typetuple;
 
-import std.algorithm : reverse, copy;
+private import std.algorithm : reverse, copy, min, 
+        max, map, swap, reduce;
+static import std.algorithm;
 
 import dstats.base, dstats.distrib, dstats.alloc, dstats.summary, dstats.sort;
     
 static import dstats.cor;
 
-private static import dstats.infotheory;
+private import dstats.infotheory;
 
 version(unittest) {
     import std.stdio, dstats.random;
@@ -2691,9 +2693,9 @@ unittest {
 package double toContingencyScore(T, U, Uint)
 (T x, U y, double function(double, double) elemFun,
  out uint xFreedom, out uint yFreedom, out uint nPtr) {
+    import dstats.infotheory : NeedsHeap;
 
-    enum needsHeap = dstats.infotheory.NeedsHeap!T ||
-        dstats.infotheory.NeedsHeap!U;
+    enum needsHeap = NeedsHeap!T || NeedsHeap!U;
     alias dstats.infotheory.ObsEnt!(ElementType!T, ElementType!U) ObsType;
 
     static if(needsHeap) {


### PR DESCRIPTION
Current imports are a bit of a mess, because there are quite a few name duplicates. In regress I therefore used more local imports, but I don't know what the "DlangScience style guide" says about that.
