### PR TITLE
Fix compilation of unittests on DMD 2.086

### DIFF
--- a/source/dstats/alloc.d
+++ b/source/dstats/alloc.d
@@ -60,7 +60,14 @@ void appendDelOld(T, U)(ref T[] to, U from)
 if(Appends!(T, U)) {
     auto old = to;
     to ~= from;
-    if (old.ptr !is to.ptr && old.ptr !is null) delete old;
+    if (old.ptr !is to.ptr && old.ptr !is null)
+    {
+        import core.memory;
+        static if (__traits(isPOD, T))
+            GC.free(old.ptr);
+        else
+            __delete(old);
+    }
 }
 
 unittest {

--- a/source/dstats/infotheory.d
+++ b/source/dstats/infotheory.d
@@ -257,7 +257,7 @@ struct ObsEnt(T...) {
 
 // Whether we can use StackTreeAA, or whether we have to use a regular AA for
 // entropy.
-private template NeedsHeap(T) {
+package template NeedsHeap(T) {
     static if(!hasIndirections!(ForeachType!(T))) {
         enum bool NeedsHeap = false;
     } else static if(isArray!(T)) {

--- a/source/dstats/random.d
+++ b/source/dstats/random.d
@@ -125,7 +125,7 @@ public import std.random; //For uniform distrib.
 import dstats.alloc, dstats.base;
 
 version(unittest) {
-    import std.stdio, dstats.tests, dstats.summary, std.range;
+    import std.stdio, dstats.tests, dstats.summary, std.range, core.memory;
 }
 
 /**Convenience function to allow one-statement creation of arrays of random
@@ -359,7 +359,7 @@ unittest {
     writeln("\tStdev Expected:  ??  Observed:  ", stdev(observ));
     writeln("\tKurtosis Expected:  ??  Observed:  ", kurtosis(observ));
     writeln("\tSkewness Expected:  ??  Observed:  ", skewness(observ));
-    delete observ;
+    GC.free(observ.ptr);
 }
 
 ///
@@ -381,7 +381,7 @@ unittest {
     writeln("\tStdev Expected:  ", sqrt(2 * df), "  Observed:  ", stdev(observ));
     writeln("\tKurtosis Expected:  ", 12 / df, "  Observed:  ", kurtosis(observ));
     writeln("\tSkewness Expected:  ", sqrt(8 / df), "  Observed:  ", skewness(observ));
-    delete observ;
+    GC.free(observ.ptr);
 }
 
 ///
@@ -463,7 +463,7 @@ unittest {
             "  Observed:  ", kurtosis(observ));
     writeln("\tSkewness Expected:  ", 1 / sqrt(lambda),
             "  Observed:  ", skewness(observ));
-    delete observ;
+    GC.free(observ.ptr);
 }
 
 ///
@@ -698,7 +698,7 @@ unittest {
                 "  Observed:  ", kurtosis(observ));
         writeln("\tSkewness Expected:  ", (1 - 2 * p) / (sqrt(n * p * (1 - p))),
                 "  Observed:  ", skewness(observ));
-        delete observ;
+        GC.free(observ.ptr);
     }
 
     testBinom(1000, 0.6);
@@ -820,7 +820,7 @@ unittest {
                 "  Observed:  ", stdev(observ));
         writeln("\tKurtosis Expected:  ?? Observed:  ", kurtosis(observ));
         writeln("\tSkewness Expected:  ", hyperSkew(n1, n2, n), "  Observed:  ", skewness(observ));
-        delete observ;
+        GC.free(observ.ptr);
     }
 
     testHyper(4, 5, 2);
@@ -871,7 +871,7 @@ unittest {
                 "  Observed:  ", kurtosis(observ));
         writeln("\tSkewness Expected:  ", (2 - p) / sqrt(1 - p),
                 "  Observed:  ", skewness(observ));
-        delete observ;
+        GC.free(observ.ptr);
     }
 
     testGeom(0.1);
@@ -908,7 +908,7 @@ unittest {
             "  Observed:  ", kurtosis(observ));
     writeln("\tSkewness Expected:  ", (2 - p) / sqrt(n * (1 - p)),
             "  Observed:  ", skewness(observ));
-    delete observ;
+    GC.free(observ.ptr);
 }
 
 ///
@@ -932,7 +932,7 @@ unittest {
     writeln("\tStdev Expected:  1.414  Observed:  ", stdev(observ));
     writeln("\tKurtosis Expected:  3  Observed:  ", kurtosis(observ));
     writeln("\tSkewness Expected:  0  Observed:  ", skewness(observ));
-    delete observ;
+    GC.free(observ.ptr);
 }
 
 ///
@@ -954,7 +954,7 @@ unittest {
     writeln("\tStdev Expected:  0.5  Observed:  ", stdev(observ));
     writeln("\tKurtosis Expected:  6  Observed:  ", kurtosis(observ));
     writeln("\tSkewness Expected:  2  Observed:  ", skewness(observ));
-    delete observ;
+    GC.free(observ.ptr);
 }
 
 private double stdGamma(RGen = Random)(double shape, ref RGen gen) {
@@ -1016,7 +1016,7 @@ unittest {
     writeln("\tStdev Expected:  0.866  Observed:  ", stdev(observ));
     writeln("\tKurtosis Expected:  2  Observed:  ", kurtosis(observ));
     writeln("\tSkewness Expected:  1.15  Observed:  ", skewness(observ));
-    delete observ;
+    GC.free(observ.ptr);
 }
 
 ///
@@ -1084,7 +1084,7 @@ unittest {
         writeln("\tStdev Expected:  ", betaStdev(a, b), "  Observed:  ", summ.stdev);
         writeln("\tKurtosis Expected:  ", betaKurtosis(a, b), "  Observed:  ", summ.kurtosis);
         writeln("\tSkewness Expected:  ", betaSkew(a, b), "  Observed:  ", summ.skewness);
-        delete observ;
+        GC.free(observ.ptr);
     }
 
     testBeta(0.5, 0.7);
@@ -1110,7 +1110,7 @@ unittest {
     writeln("\tStdev Expected:  ", PI * PI * 3, " Observed:  ", stdev(observ));
     writeln("\tKurtosis Expected:  1.2  Observed:  ", kurtosis(observ));
     writeln("\tSkewness Expected:  0  Observed:  ", skewness(observ));
-    delete observ;
+    GC.free(observ.ptr);
 }
 
 ///
@@ -1149,7 +1149,7 @@ unittest {
     elem = rWeibull(2.0L, 3.0L);
     auto ksRes = ksTest(observ, parametrize!(weibullCDF)(2.0, 3.0));
     writeln("100k samples from weibull(2, 3):  K-S P-val:  ", ksRes.p);
-    delete observ;
+    GC.free(observ.ptr);
 }
 
 ///


### PR DESCRIPTION
Change visibility of `NeedsHeap` since explicit import of private members doesn't work in DMD 2.086, and replace use of deprecated `delete` keyword. Currently not all unittests are passing (two assertions in `dstats.infotheory.d` and one assertion in `dstats.distrib` failing due to slightly less than expected precision).